### PR TITLE
LXM mods for awx-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= $(shell git describe --tags)
+VERSION ?= lxm-devel
 PREV_VERSION ?= $(shell git describe --abbrev=0 --tags $(shell git rev-list --tags --skip=1 --max-count=1))
 
 CONTAINER_CMD ?= docker
@@ -39,7 +39,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # ansible.com/awx-operator-bundle:$VERSION and ansible.com/awx-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/ansible/awx-operator
+IMAGE_TAG_BASE ?= us-central1-docker.pkg.dev/civic-origin-380/lxm-docker/awx-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= lxm-devel
+VERSION ?= lxm-devel-0
 PREV_VERSION ?= $(shell git describe --abbrev=0 --tags $(shell git rev-list --tags --skip=1 --max-count=1))
 
 CONTAINER_CMD ?= docker

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= lxm-devel-0
+VERSION ?= $(shell git describe --abbrev=0)
 PREV_VERSION ?= $(shell git describe --abbrev=0 --tags $(shell git rev-list --tags --skip=1 --max-count=1))
 
 CONTAINER_CMD ?= docker

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/ansible/awx-operator
+  newName: us-central1-docker.pkg.dev/civic-origin-380/lxm-docker/awx-operator
   newTag: latest

--- a/roles/installer/templates/networking/ingress.yaml.j2
+++ b/roles/installer/templates/networking/ingress.yaml.j2
@@ -27,7 +27,7 @@ spec:
 {% if not ingress_hosts %}
     - http:
         paths:
-          - path: '{{ ingress_path }}'
+          - path: '{{ (ingress_path + '/*').replace("//","/") }}'
             pathType: '{{ ingress_path_type }}'
             backend:
               service:


### PR DESCRIPTION
1. adds ingress path patch
2. uses git branch version with --abbrev=0
3. changes image paths in templates